### PR TITLE
Removing unused Illuminate\Support package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,8 +16,7 @@
     },
     "require": {
         "php": ">=5.4.0",
-        "guzzlehttp/guzzle": "~4.1",
-        "illuminate/support": "~4.2"
+        "guzzlehttp/guzzle": "~4.1"
     },
     "require-dev": {
         "mockery/mockery": "0.9.*",

--- a/src/Mcprohosting/CloudFlare/RequestFactory.php
+++ b/src/Mcprohosting/CloudFlare/RequestFactory.php
@@ -37,9 +37,9 @@ class RequestFactory
     {
         $request = new HttpRequest(new Client, new Resolver);
 
-        $request->setEmail($this->authEmail)
-                ->setKey($this->authKey)
-                ->setBaseUrl($this->baseUrl);
+        $request->setEmail($this->authEmail);
+        $request->setKey($this->authKey);
+        $request->setBaseUrl($this->baseUrl);
 
         return $request;
     }


### PR DESCRIPTION
The `Illuminate\Support` package isn't being used, and it can conflict if other packages require different versions of it.
